### PR TITLE
Added missing requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     install_requires=["simplejson", "numpy", "pydantic",
                       "urllib3", "python-dateutil", "uvicorn", "fastapi",
                       "python-multipart", "tabulate", "pandas", "lxml", "pytest", "httpx",
-                      "rich", "typing", "html5lib"],
+                      "rich", "typing", "html5lib", "typer"],
     package_data={
         "espp2": ["*.json"],
     },


### PR DESCRIPTION
typer was missing in setup.py. It is listed in requirements.txt but that doesn't get used unless you pip install -r it.