### PR TITLE
morgan-import: Use an auxiliary dict() for importer to provide info

### DIFF
--- a/espp2/plugins/pickle.py
+++ b/espp2/plugins/pickle.py
@@ -8,6 +8,7 @@ import pickle
 import logging
 import datetime
 import codecs
+from typing import Tuple
 from pprint import pformat    # Pretty-print objects for debugging
 from espp2.datamodels import Transactions, Amount, Deposit, EntryTypeEnum, Sell, Tax, Dividend_Reinv
 from espp2.datamodels import Dividend, Taxsub, Wire, Fee, Transfer
@@ -183,7 +184,7 @@ methods = {
     'JOURNAL': do_wire,
 }
 
-def read(pickle_file, filename='') -> Transactions:
+def read(pickle_file, filename='') -> Tuple[Transactions, dict]:
     '''Main entry point of plugin. Return normalized Python data structure.'''
     records = []
     source = f'pickle:{filename}'
@@ -210,4 +211,4 @@ def read(pickle_file, filename='') -> Transactions:
         except KeyError as e:
             raise ValueError(f'Error: Unexpected pickle-file record: {rectype} {record}') from e
 
-    return Transactions(transactions=records)
+    return Transactions(transactions=records), dict()

--- a/espp2/plugins/schwab.py
+++ b/espp2/plugins/schwab.py
@@ -6,6 +6,7 @@ Schwab CSV normalizer.
 
 import csv
 from decimal import Decimal
+from typing import Tuple
 import codecs
 import io
 import logging
@@ -163,7 +164,7 @@ def subdata(action, description, date, value):
         newlist.append(newv)
     return newlist
 
-def read(csv_file, filename='') -> Transactions:
+def read(csv_file, filename='') -> Tuple[Transactions, dict]:
     '''Main entry point of plugin. Return normalized Python data structure.'''
 
     key_conv = {'DATE': 'date',
@@ -221,4 +222,4 @@ def read(csv_file, filename='') -> Transactions:
         newlist.append(newv)
 
     sorted_transactions = sorted(newlist, key=lambda d: d['date'])
-    return Transactions(transactions=sorted_transactions)
+    return Transactions(transactions=sorted_transactions), dict()

--- a/espp2/plugins/td.py
+++ b/espp2/plugins/td.py
@@ -209,4 +209,4 @@ def read(raw_data, filename=''):
         r['source'] = f'td:{filename}'
         trans.append(parse_obj_as(Entry, r))
 
-    return Transactions(transactions=trans)
+    return Transactions(transactions=trans), dict()

--- a/espp2/transactions.py
+++ b/espp2/transactions.py
@@ -15,7 +15,7 @@ import os
 import importlib
 import argparse
 import logging
-from typing import Union
+from typing import Union, Tuple
 import typer
 from fastapi import UploadFile
 import starlette
@@ -93,8 +93,8 @@ def guess_format(filename, data) -> str:
 
     raise ValueError('Unable to guess format', fname, extension, filebytes)
 
-def normalize(data: Union[UploadFile, typer.FileText]) -> Transactions:
-    '''Normalize transactions'''
+def normalize(data: Union[UploadFile, typer.FileText]) -> Tuple[Transactions, dict]:
+    '''Normalize transactions, return transactions and status/info string'''
     if isinstance(data, starlette.datastructures.UploadFile):
         filename = data.filename
         fd = data.file
@@ -112,7 +112,7 @@ def main():
     '''Main function'''
     args = get_arguments()
     logger.debug('Arguments: %s', args)
-    trans_obj = normalize(args.transaction_file)
+    trans_obj, auxiliary = normalize(args.transaction_file)
     logger.info('Converting to JSON')
     j = trans_obj.json(indent=4)
 


### PR DESCRIPTION
The Morgan Stanley importer bootstraps holdings for 2021 by means of the holding tables in the HTML files with statements.

The "skjermingsfradrag" needs to be calculated differently for this case, since the complete history is not available, and we must make some assumptions and conservative choices for 2021/2022 in order to not claim too much tax deduction for skjermingsfradrag.

Communicate this need through the auxiliary import data, so the importer chosen (and specific circumstances), can guide the correcting of the skjermingsfradrag later in the process, when the holdings have been established.