### PR TITLE
Update pydantic

### DIFF
--- a/espp2/portfolio.py
+++ b/espp2/portfolio.py
@@ -124,7 +124,7 @@ class PortfolioSale(BaseModel):
         l.append((row, columns.index("Price USD"), round(self.sell_price.value, 2)))
         l.append((row, columns.index("Exchange Rate"), self.sell_price.nok_exchange_rate))
         l.append((row, columns.index("Gain PS"),
-                  f'={index_to_cell(row, columns.index("Price"))}-{self.parent.get_coord('Price')}'))
+                  f'={index_to_cell(row, columns.index("Price"))}-{self.parent.get_coord("Price")}'))
 
         l.append((row, columns.index("Gain PS USD"),
                     f'={index_to_cell(row, columns.index("Price USD"))}-{self.parent.get_coord("Price USD")}'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ decorator==5.1.1
 dill==0.3.6
 docopt==0.6.2
 executing==1.2.0
-fastapi==0.92.0
+fastapi==0.110.0
 h11==0.14.0
 idna==3.4
 iniconfig==2.0.0
@@ -37,7 +37,7 @@ prompt-toolkit==3.0.36
 ptyprocess==0.7.0
 pure-eval==0.2.2
 pycodestyle==2.10.0
-pydantic==1.10.5
+pydantic==2.6.3
 Pygments==2.14.0
 pylint==2.16.2
 pytest==7.2.1
@@ -51,12 +51,12 @@ simplejson==3.18.3
 six==1.16.0
 sniffio==1.3.0
 stack-data==0.6.2
-starlette==0.25.0
+starlette==0.36.3
 tabulate==0.9.0
 tomlkit==0.11.6
 traitlets==5.9.0
 typer==0.7.0
-typing_extensions==4.5.0
+typing_extensions==4.10.0
 urllib3==1.26.14
 uvicorn==0.20.0
 wcwidth==0.2.6


### PR DESCRIPTION
Usage of TypeAdapter requires pydantic v2.x, and updates on its dependencies.

Also change a '' to "" inside an f-string