### PR TITLE
Fix crash when fee's field on a sale is empty

### DIFF
--- a/espp2/plugins/schwab-json.py
+++ b/espp2/plugins/schwab-json.py
@@ -116,10 +116,12 @@ def sale(csv_item, source):
     """Process sale"""
     d = fixup_date(csv_item["Date"])
     try:
-        fee = fixup_price_negative(d, "USD", csv_item["FeesAndCommissions"])
+        fee_str = csv_item["FeesAndCommissions"] or "$0.00"
+        fee = fixup_price_negative(d, "USD", fee_str)
     except InvalidOperation:
-        fee = None
-    assert fee.value < Decimal("0.00")
+        logger.error(f'Error processing fee: "{csv_item["FeesAndCommissions"]}"')
+        raise
+    assert fee.value <= Decimal("0.00")
     saleprice = fixup_price(d, "USD", get_saleprice(csv_item))
     grossproceeds = fixup_price(d, "USD", csv_item["Amount"])
     g = get_grossproceeds(csv_item)


### PR DESCRIPTION
If a sale has no fees the fee's field is empty, and causes a crash. Fixed the issue and added error logging to print what we are trying to parse, as well as raise on the issue as rasing on the assert does not provide much of context around the issue.