### PR TITLE
Implement EOY balance validation and adjustment in tax report

### DIFF
--- a/espp2/datamodels.py
+++ b/espp2/datamodels.py
@@ -709,6 +709,13 @@ class ESPPInfo(BaseModel):
     roi_net: Decimal
 
 
+class EOYBalanceComparison(BaseModel):
+    """Comparison of stocks and cash for the last two years"""
+
+    year: int
+    cash_qty: Decimal
+
+
 class TaxReport(BaseModel):
     """Tax report"""
 
@@ -722,6 +729,7 @@ class TaxReport(BaseModel):
     unmatched_wires: list[WireAmount]
     prev_holdings: Optional[Holdings] = None
     espp_extra_info: list[ESPPInfo] = []
+    eoy_balance_comparison: Optional[EOYBalanceComparison] = None
 
 
 class CashModel(BaseModel):

--- a/espp2/main.py
+++ b/espp2/main.py
@@ -23,10 +23,12 @@ from espp2.datamodels import (
     ForeignShares,
     TaxSummary,
     CreditDeduction,
+    EOYBalanceComparison,
 )
 from espp2.report import print_ledger, print_cash_ledger, print_report_holdings
 from espp2.portfolio import Portfolio
 from espp2 import __version__
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +59,7 @@ def tax_report(  # noqa: C901
     portfolio_engine: bool,
     verbose: bool = False,
     feature_flags=[],
+    eoy_balance: Optional[list[EOYBalanceComparison]] = None,
 ) -> Tuple[TaxReport, Holdings, TaxSummary]:
     """Generate tax report"""
 
@@ -64,7 +67,14 @@ def tax_report(  # noqa: C901
 
     # Run the chosen tax calculation engine
     portfolio = Portfolio(
-        year, broker, this_year, wires, prev_holdings, verbose, feature_flags
+        year,
+        broker,
+        this_year,
+        wires,
+        prev_holdings,
+        verbose,
+        feature_flags,
+        expected_cash_balance=eoy_balance[0] if eoy_balance else None,
     )
     if portfolio_engine is False:
         p = Positions(year, prev_holdings, this_year, wires)
@@ -94,6 +104,7 @@ def tax_report(  # noqa: C901
     report["eoy_balance"] = {year - 1: prev_year_eoy, year: this_year_eoy}
     logger.info("Previous year eoy: %s", prev_year_eoy)
     logger.info("This tax year eoy: %s", this_year_eoy)
+
     try:
         report["dividends"] = p.dividends()
     except InvalidPositionException as err:
@@ -413,6 +424,7 @@ def do_taxes(
     portfolio_engine,
     verbose=False,
     feature_flags=[],
+    eoy_balance=None,
 ) -> Tuple[TaxReport, Holdings, TaxSummary]:
     """Do taxes
     This function is run in two phases:
@@ -459,4 +471,5 @@ def do_taxes(
         portfolio_engine,
         verbose=verbose,
         feature_flags=feature_flags,
+        eoy_balance=eoy_balance,
     )

--- a/espp2/portfolio.py
+++ b/espp2/portfolio.py
@@ -31,6 +31,7 @@ from espp2.datamodels import (
     NegativeAmount,
     GainAmount,
     NativeAmount,
+    EOYBalanceComparison,
 )
 from espp2.fmv import FMV, get_tax_deduction_rate, Fundamentals, todate
 from espp2.cash import Cash
@@ -876,13 +877,18 @@ class Portfolio:
         holdings: Holdings,
         verbose: bool,
         feature_flags: list[FeatureFlagEnum],
+        expected_cash_balance: Optional[EOYBalanceComparison] = None,
     ):
         self.year = year
         self.taxes = []
         self.positions = []
         self.new_positions = []
         if holdings and holdings.cash:
-            self.cash = Cash(year=year, opening_balance=holdings.cash)
+            self.cash = Cash(
+                year=year,
+                opening_balance=holdings.cash,
+                expected_cash_balance=expected_cash_balance,
+            )
         else:
             self.cash = Cash(year=year)
         self.broker = broker


### PR DESCRIPTION
- Added support for validating user-provided EOY balance (stocks & cash) in the tax report endpoint.
- Introduced a new optional object in the tax report endpoint to handle year, cash, and stock balances for the last two years.
- Raises an error if the mismatch exceeds 10 USD.
- Logs a warning and updates the cash ledger with a `CashAdjustment` entry for mismatches under 10 USD.